### PR TITLE
Introduce an integration with MultilingualPress to sync the featured image

### DIFF
--- a/inc/integrations/multilingualpress/namespace.php
+++ b/inc/integrations/multilingualpress/namespace.php
@@ -58,8 +58,17 @@ function sync_thumbnail( array $keys, RelationshipContext $context, PhpServerReq
 
 	$source_attachment_id = get_post_meta( $source_post_id, '_thumbnail_id', true );
 
-	// Bail if there's no featured image
+	// Return early if there's no featured image
 	if ( empty( $source_attachment_id ) ) {
+		// Switch to the target site
+		switch_to_blog( $remote_site_id );
+
+		// Remove the featured image from the remote post too
+		delete_post_meta( $remote_post_id, '_thumbnail_id' );
+
+		// Switch back to the source site
+		restore_current_blog();
+
 		return $keys;
 	}
 

--- a/inc/integrations/multilingualpress/namespace.php
+++ b/inc/integrations/multilingualpress/namespace.php
@@ -7,7 +7,7 @@
 
 declare( strict_types=1 );
 
-namespace AssetManagerFramework\MultilingualPress;
+namespace AssetManagerFramework\Integrations\MultilingualPress;
 
 use Inpsyde\MultilingualPress\ {
 	TranslationUi\Post\RelationshipContext,

--- a/inc/integrations/multilingualpress/namespace.php
+++ b/inc/integrations/multilingualpress/namespace.php
@@ -15,10 +15,21 @@ use Inpsyde\MultilingualPress\ {
 	Framework\Http\PhpServerRequest,
 };
 
+/**
+ * Bootstrap actions and filters.
+ */
 function bootstrap() : void {
 	add_filter( PostRelationSaveHelper::FILTER_SYNC_KEYS, __NAMESPACE__ . '\sync_thumbnail', 10, 3 );
 }
 
+/**
+ * Synchronises the featured image to the translation site when requested.
+ *
+ * @param string[]            $keys    Array of post meta key names to sync. Unused.
+ * @param RelationshipContext $context Context for the current translation.
+ * @param PhpServerRequest    $request The translation UI request.
+ * @return string[] The unmodified array of post meta keys to sync.
+ */
 function sync_thumbnail( array $keys, RelationshipContext $context, PhpServerRequest $request ) : array {
 	$translations = $request->bodyValue(
 		'multilingualpress',

--- a/inc/integrations/multilingualpress/namespace.php
+++ b/inc/integrations/multilingualpress/namespace.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Integration with MultilingualPress 3.
+ *
+ * @package asset-manager-framework
+ */
+
+declare( strict_types=1 );
+
+namespace AssetManagerFramework\MultilingualPress;
+
+use Inpsyde\MultilingualPress\ {
+	TranslationUi\Post\RelationshipContext,
+	TranslationUi\Post\PostRelationSaveHelper,
+	Framework\Http\PhpServerRequest,
+};
+
+function bootstrap() : void {
+	add_filter( PostRelationSaveHelper::FILTER_SYNC_KEYS, __NAMESPACE__ . '\sync_thumbnail', 10, 3 );
+}
+
+function sync_thumbnail( array $keys, RelationshipContext $context, PhpServerRequest $request ) : array {
+	$translations = $request->bodyValue(
+		'multilingualpress',
+		INPUT_POST,
+		FILTER_DEFAULT,
+		FILTER_FORCE_ARRAY
+	);
+
+	foreach ( $translations as $translation ) {
+		if ( $translation['remote-thumbnail-copy'] !== '1' ) {
+			continue;
+		}
+
+		$remote_site_id = $context->remoteSiteId();
+		$remote_post_id = $context->remotePostId();
+		$source_post_id = $context->sourcePostId();
+
+		$source_attachment = get_post( get_post_meta( $source_post_id, '_thumbnail_id', true ) );
+		$source_attachment_meta = get_post_meta( $source_attachment->ID );
+
+		// Switch to the target site
+		switch_to_blog( $remote_site_id );
+
+		$remote_attachment_id = get_post_meta( $remote_post_id, '_thumbnail_id', true );
+
+		if ( ! $remote_attachment_id ) {
+			// No remote attachment, create one copied from source attachment
+			$source_attachment->ID = null;
+			$remote_attachment_id = wp_insert_attachment(
+				$source_attachment,
+				false,
+				$remote_post_id
+			);
+
+			// Set featured image ID for remote post
+			add_post_meta( $remote_post_id, '_thumbnail_id', $remote_attachment_id );
+		} else {
+			// Update existing remote attachment with source attachment
+			$source_attachment->ID = $remote_attachment_id;
+			$source_attachment->post_parent = $remote_post_id;
+			wp_update_post(
+				$source_attachment
+			);
+		}
+
+		// Iterate all source attachment metadata and apply to remote post
+		foreach ( $source_attachment_meta as $key => $values ) {
+			foreach ( $values as $value ) {
+				update_post_meta( $remote_attachment_id, $key, maybe_unserialize( $value ) );
+			}
+		}
+
+		// Switch back to the source site
+		restore_current_blog();
+	}
+
+	return $keys;
+}

--- a/inc/integrations/multilingualpress/namespace.php
+++ b/inc/integrations/multilingualpress/namespace.php
@@ -19,7 +19,7 @@ use Inpsyde\MultilingualPress\ {
  * Bootstrap actions and filters.
  */
 function bootstrap() : void {
-	add_filter( PostRelationSaveHelper::FILTER_SYNC_KEYS, __NAMESPACE__ . '\sync_thumbnail', 10, 3 );
+	add_filter( PostRelationSaveHelper::FILTER_SYNC_KEYS, __NAMESPACE__ . '\\sync_thumbnail', 10, 3 );
 }
 
 /**

--- a/inc/integrations/multilingualpress/namespace.php
+++ b/inc/integrations/multilingualpress/namespace.php
@@ -82,7 +82,7 @@ function sync_thumbnail( array $keys, RelationshipContext $context, PhpServerReq
 		// There doesn't appear to be an error reporting mechanism in MLP, so we'll just bail if there's a problem
 		// creating the attachment on the remote site
 		if ( is_wp_error( $remote_attachment_id ) ) {
-			return $keys;;
+			return $keys;
 		}
 
 		// Set featured image ID for remote post

--- a/inc/integrations/multilingualpress/readme.md
+++ b/inc/integrations/multilingualpress/readme.md
@@ -1,0 +1,19 @@
+# MultilingualPress (MLP) Integration
+
+This is an integration later between AMF and [MultilingualPress 3](https://multilingualpress.org/). MLP 2 and earlier have not been tested.
+
+## Issues
+
+This integration addresses the following issues:
+
+1. **Featured images do not synchronise to the translation** ([#3](https://github.com/humanmade/asset-manager-framework/issues/3))
+
+	The featured image doesn't get synced when copying a post from the source to the translation and choosing the *Advanced → Copy featured image* option within MLP.
+
+	The reason the sync fails is because MLP performs checks to ensure the attachment file exists before syncing it, and bails out if not. This is expected behaviour.
+
+	This integration layer syncs the attachment and its metadata whenever the *Copy featured image* option is checked, without performing any checks for the validity of the attachment file.
+
+## Documentation
+
+* https://multilingualpress.org/docs/copy-post-meta/

--- a/inc/integrations/multilingualpress/readme.md
+++ b/inc/integrations/multilingualpress/readme.md
@@ -17,3 +17,4 @@ This integration addresses the following issues:
 ## Documentation
 
 * https://multilingualpress.org/docs/copy-post-meta/
+* https://multilingualpress.org/docs/run-code-copy-source-content-option-checked/

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,6 +40,11 @@ function init() : void {
 	require_once __DIR__ . '/Document.php';
 	require_once __DIR__ . '/MediaList.php';
 
+	if ( class_exists( '\Inpsyde\MultilingualPress\MultilingualPress', false ) ) {
+		require_once __DIR__ . '/integrations/multilingualpress/namespace.php';
+		MultilingualPress\bootstrap();
+	}
+
 	do_action( 'amf/loaded' );
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,6 +40,7 @@ function init() : void {
 	require_once __DIR__ . '/Document.php';
 	require_once __DIR__ . '/MediaList.php';
 
+	// Load the integration layer for MLP if it's active
 	if ( class_exists( '\Inpsyde\MultilingualPress\MultilingualPress', false ) ) {
 		require_once __DIR__ . '/integrations/multilingualpress/namespace.php';
 		MultilingualPress\bootstrap();

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -43,7 +43,7 @@ function init() : void {
 	// Load the integration layer for MLP if it's active
 	if ( class_exists( '\Inpsyde\MultilingualPress\MultilingualPress', false ) ) {
 		require_once __DIR__ . '/integrations/multilingualpress/namespace.php';
-		MultilingualPress\bootstrap();
+		Integrations\MultilingualPress\bootstrap();
 	}
 
 	do_action( 'amf/loaded' );

--- a/readme.md
+++ b/readme.md
@@ -24,11 +24,15 @@ The following features work as expected:
 * [X] XML-RPC requests for media
 * [X] Any code that calls `wp.media()` to open the media manager and work with the selected attachments
 
-The following custom field libraries have been tested and are known to be compatible:
+The following custom field libraries have been tested and are compatible out of the box:
 
 * [X] CMB2
 * [X] Advanced Custom Fields (ACF)
 * [X] Fieldmanager
+
+The following third party plugins are supported via an integration layer included in MLP:
+
+* [X] MultilingualPress 3
 
 The following new features are planned but not yet implemented:
 


### PR DESCRIPTION
Fixes #3 .

With AMF in use, MultilingualPress (v3) doesn't sync the featured image when copying a post from the source to the translation and choosing the option to sync the featured image.

The reason the sync fails is because MLP performs checks to ensure the attachment file exists before syncing it, and bails out if not. This is expected behaviour. I might open an enhancement request for MLP to introduce a filter which allows the sync to continue even if the file doesn't exist, because any system that offloads attachments and doesn't provide corresponding local filesystem mapping will fail in the same way.

This fix syncs the attachment and its metadata whenever the "Copy featured image" option is checked, without performing any checks for the validity of the attachment file.

**Note:** The documentation at https://multilingualpress.org/docs/run-code-copy-source-content-option-checked/ is incorrect. The translations mustn't be iterated because the filter is already applied once for each translation, instead the parameters for the current translation needs to be plucked from the request. I've submitted a support ticket to MLP to get this corrected.