### PR TITLE
Add setter for author information

### DIFF
--- a/inc/Media.php
+++ b/inc/Media.php
@@ -17,6 +17,8 @@ class Media {
 	public $amfMeta = [];
 	public $attachmentExists = false;
 	public $author = 0;
+	public $authorLink = '';
+	public $authorName = '';
 	public $caption = '';
 	public $date = null;
 	public $dateFormatted = null;
@@ -139,6 +141,13 @@ class Media {
 
 	final public function set_sizes( array $sizes ) : self {
 		$this->sizes = $sizes;
+
+		return $this;
+	}
+
+	final public function set_author( string $author_name, string $author_link = '' ) : self {
+		$this->authorName = $author_name;
+		$this->authorLink = $author_link;
 
 		return $this;
 	}

--- a/inc/Media.php
+++ b/inc/Media.php
@@ -147,7 +147,7 @@ class Media {
 
 	final public function set_author( string $author_name, string $author_link = '' ) : self {
 		$this->authorName = $author_name;
-		$this->authorLink = $author_link;
+		$this->authorLink = esc_url_raw( $author_link );
 
 		return $this;
 	}


### PR DESCRIPTION
A (remote) asset might have attribution information such as author name and maybe a URL.

This PR adds a dedicated setter for the `authorName` and `authorLink` properties that are displayed in the media template.