### PR TITLE
Move to Composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,11 @@
 		"phpcompatibility/phpcompatibility-wp": "~2.1.0",
 		"wp-coding-standards/wpcs": "~2.2.0"
 	},
+	"autoload": {
+		"psr-4": {
+			"AssetManagerFramework\\": "inc/"
+		}
+	},
 	"scripts": {
 		"test:cs": [
 			"vendor/bin/phpcs -nps --colors --report-code --report-summary --report-width=80 ."

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,18 +30,8 @@ function bootstrap() : void {
 }
 
 function init() : void {
-	require_once __DIR__ . '/Provider.php';
-	require_once __DIR__ . '/BlankProvider.php';
-	require_once __DIR__ . '/Media.php';
-	require_once __DIR__ . '/Playable.php';
-	require_once __DIR__ . '/Image.php';
-	require_once __DIR__ . '/Audio.php';
-	require_once __DIR__ . '/Video.php';
-	require_once __DIR__ . '/Document.php';
-	require_once __DIR__ . '/MediaList.php';
-
 	// Load the integration layer for MLP if it's active
-	if ( class_exists( '\Inpsyde\MultilingualPress\MultilingualPress', false ) ) {
+	if ( class_exists( 'Inpsyde\MultilingualPress\MultilingualPress', false ) ) {
 		require_once __DIR__ . '/integrations/multilingualpress/namespace.php';
 		Integrations\MultilingualPress\bootstrap();
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -30,6 +30,10 @@ declare( strict_types=1 );
 
 namespace AssetManagerFramework;
 
+if ( is_readable( __DIR__ .'/vendor/autoload.php' ) ) {
+	include_once __DIR__ .'/vendor/autoload.php';
+}
+
 require_once __DIR__ . '/inc/namespace.php';
 
 bootstrap();


### PR DESCRIPTION
This PR introduces Composer autoloading, see #6.

I decided to **not** add the `inc/namespace.php` file to `autoload.file` as that would mean it'll **always** get loaded, even if the plugin is not active.