### PR TITLE
Move image property from Playable to Media

### DIFF
--- a/inc/Media.php
+++ b/inc/Media.php
@@ -28,6 +28,7 @@ class Media {
 	public $height = null;
 	public $icon = '';
 	public $id = '';
+	public $image = null;
 	public $link = '';
 	public $menuOrder = 0;
 	public $meta = false;
@@ -71,6 +72,16 @@ class Media {
 
 	final public function set_filename( string $filename ) : self {
 		$this->filename = $filename;
+
+		return $this;
+	}
+
+	final public function set_image( string $image ) : self {
+		$this->image = [
+			'src' => esc_url_raw( $image ),
+			'width' => 400,
+			'height' => 400,
+		];
 
 		return $this;
 	}

--- a/inc/Playable.php
+++ b/inc/Playable.php
@@ -28,16 +28,6 @@ abstract class Playable extends Media {
 		return $this;
 	}
 
-	final public function set_image( string $image ) : self {
-		$this->image = [
-			'src' => $image,
-			'width' => 400,
-			'height' => 400,
-		];
-
-		return $this;
-	}
-
 	final public function set_thumb( string $thumb ) : self {
 		$this->thumb = [
 			'src' => $thumb,


### PR DESCRIPTION
Currently, only _playable_ assets (i.e., `Audio` and `Video`) have a setter for the `image` property.

However, the media library (i.e., the templates) can handle image for any type, really. This is also useful for, say PDF files that show an image version of their first page.