### PR TITLE
Store image sizes as attachment metadata if provider does not support dynamic image resizing

### DIFF
--- a/inc/Provider.php
+++ b/inc/Provider.php
@@ -54,6 +54,10 @@ abstract class Provider {
 		return false;
 	}
 
+	public function supports_dynamic_image_resizing() : bool {
+		return false;
+	}
+
 	public function supports_filter_search() : bool {
 		return true;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -135,9 +135,9 @@ function ajax_select() : void {
 			$metadata['sizes'] = array_map( function ( array $size ) use ( $mime_type ): array {
 
 				return [
-					'file'      => $size['url'],
-					'width'     => $size['width'],
-					'height'    => $size['height'],
+					'file' => $size['url'],
+					'width' => $size['width'],
+					'height' => $size['height'],
 					'mime-type' => $mime_type,
 				];
 			}, $selection['sizes'] );


### PR DESCRIPTION
Currently, the image sizes specified by a provider ( in the `sizes` property) are not persisted. This means the `_wp_attachment_metadata` field does not have the `sizes` property.

This PR automatically stores all provided size information, in the required format, unless the provider allows for dynamic image resizing. This can be specified by overriding the new `supports_dynamic_image_resizing` method.