### PR TITLE
Avoid an infinite loop with `get_attached_file()`

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -153,7 +153,7 @@ function ajax_select() : void {
 }
 
 function replace_attached_file( $file, int $attachment_id ) : string {
-	$metadata = wp_get_attachment_metadata( $attachment_id );
+	$metadata = wp_get_attachment_metadata( $attachment_id, true );
 
 	return $metadata['file'] ?? '';
 }


### PR DESCRIPTION
I was seeing an infinite loop on my local Altis site.

The cause is actually several plugins, including at least Smart Media and Safe SVG, which hook into `wp_get_attachment_metadata` and either call `get_attached_file()` directly or call it indirectly via another function such as `wp_attachment_is_image()` which calls it. This causes an infinite loop when the filter attached to `get_attached_file` in this framework calls `wp_get_attachment_metadata()` again.

I did some investigation and none of the `wp_get_attachment_metadata` filters in use (on a default Altis site at least) are adjusting the value of the `file` property, so we can fix this by setting the `$unfiltered` parameter to true which avoids the `wp_get_attachment_metadata` filter.