### PR TITLE
Throw an exception if the provider returns more results than it should

### DIFF
--- a/inc/Provider.php
+++ b/inc/Provider.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace AssetManagerFramework;
 
 use Exception;
+use RangeException;
 use WP_Query;
 
 abstract class Provider {
@@ -78,7 +79,7 @@ abstract class Provider {
 	 * Fetches a list of media items that are ultimately used directly by the media managaer.
 	 *
 	 * @param array $args Raw query arguments from the POST request in the media manager.
-	 * @throws Exception Thrown if the provider returns too many media items.
+	 * @throws RangeException Thrown if the provider returns too many media items.
 	 * @return MediaList Media items for use in the media manager.
 	 */
 	final public function request_items( array $args ) : MediaList {
@@ -132,7 +133,7 @@ abstract class Provider {
 		}
 
 		if ( isset( $args['posts_per_page'] ) && ( $args['posts_per_page'] > 0 ) && count( $array ) > $args['posts_per_page'] ) {
-			throw new Exception(
+			throw new RangeException(
 				sprintf(
 					/* translators: %s: Argument name */
 					__( 'Too many media items were returned by the provider. The "%s" argument must be respected.', 'asset-manager-framework' ),

--- a/inc/Provider.php
+++ b/inc/Provider.php
@@ -78,7 +78,7 @@ abstract class Provider {
 	 * Fetches a list of media items that are ultimately used directly by the media managaer.
 	 *
 	 * @param array $args Raw query arguments from the POST request in the media manager.
-	 * @throws Exception Thrown if an unrecoverable error occurs.
+	 * @throws Exception Thrown if the provider returns too many media items.
 	 * @return MediaList Media items for use in the media manager.
 	 */
 	final public function request_items( array $args ) : MediaList {

--- a/inc/Provider.php
+++ b/inc/Provider.php
@@ -78,6 +78,7 @@ abstract class Provider {
 	 * Fetches a list of media items that are ultimately used directly by the media managaer.
 	 *
 	 * @param array $args Raw query arguments from the POST request in the media manager.
+	 * @throws Exception Thrown if an unrecoverable error occurs.
 	 * @return MediaList Media items for use in the media manager.
 	 */
 	final public function request_items( array $args ) : MediaList {
@@ -128,6 +129,16 @@ abstract class Provider {
 
 		if ( ! $array ) {
 			return $items;
+		}
+
+		if ( isset( $args['posts_per_page'] ) && ( $args['posts_per_page'] > 0 ) && count( $array ) > $args['posts_per_page'] ) {
+			throw new Exception(
+				sprintf(
+					/* translators: %s: Argument name */
+					__( 'Too many media items were returned by the provider. The "%s" argument must be respected.', 'asset-manager-framework' ),
+					'posts_per_page'
+				)
+			);
 		}
 
 		$names = array_column( $array, 'id' );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace AssetManagerFramework;
 
 use Exception;
+use WP_Http;
 use WP_Post;
 use WP_Query;
 
@@ -211,7 +212,8 @@ function ajax_query_attachments() : void {
 					'code' => $e->getCode(),
 					'message' => $e->getMessage(),
 				],
-			]
+			],
+			WP_Http::INTERNAL_SERVER_ERROR
 		);
 	}
 


### PR DESCRIPTION
Fixes #4.

This makes two changes:

1. Returns an HTTP 500 response when there's a problem with the response from the provider so it's more visible to developers while we wait for #22 .
2. Throws an exception (which is caught in `ajax_query_attachments()` and converted to a JSON error) if the provider returns too many results.