### PR TITLE
Support for file uploads

### DIFF
--- a/inc/FileUpload.php
+++ b/inc/FileUpload.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Representation of a single element from the `$_FILES` superglobal in PHP.
+ *
+ * @package asset-manager-framework
+ */
+
+declare( strict_types=1 );
+
+namespace AssetManagerFramework;
+
+class FileUpload {
+
+	/**
+	 * Undocumented variable
+	 *
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * Undocumented variable
+	 *
+	 * @var string
+	 */
+	public $type;
+
+	/**
+	 * Undocumented variable
+	 *
+	 * @var int
+	 */
+	public $size;
+
+	/**
+	 * Undocumented variable
+	 *
+	 * @var string
+	 */
+	public $tmp_name;
+
+	/**
+	 * Undocumented variable
+	 *
+	 * @var int
+	 */
+	public $error;
+
+	public function __construct( array $file ) {
+		$this->name = $file['name'];
+		$this->type = $file['type'];
+		$this->size = $file['size'];
+		$this->tmp_name = $file['tmp_name'];
+		$this->error = $file['error'];
+	}
+}

--- a/inc/Provider.php
+++ b/inc/Provider.php
@@ -75,6 +75,10 @@ abstract class Provider {
 		return true;
 	}
 
+	protected function upload( FileUpload $file ) : Media {
+		throw new Exception( __( 'Sorry, you are not allowed to upload files.', 'asset-manager-framework' ) );
+	}
+
 	/**
 	 * Fetches a list of media items that are ultimately used directly by the media managaer.
 	 *

--- a/inc/Provider.php
+++ b/inc/Provider.php
@@ -75,6 +75,22 @@ abstract class Provider {
 		return true;
 	}
 
+	final public function handle_upload( FileUpload $file, int $parent = null ) : Media {
+		if ( ! $this->supports_asset_create() ) {
+			throw new Exception( __( 'Sorry, you are not allowed to upload files.', 'asset-manager-framework' ) );
+		}
+
+		if ( $parent && ! current_user_can( 'edit_post', $parent ) ) {
+			throw new Exception( __( 'Sorry, you are not allowed to attach files to this post.', 'asset-manager-framework' ) );
+		}
+
+		$media = $this->upload( $file );
+
+		$media->id = insert_attachment( $media, $this, $parent )->ID;
+
+		return $media;
+	}
+
 	protected function upload( FileUpload $file ) : Media {
 		throw new Exception( __( 'Sorry, you are not allowed to upload files.', 'asset-manager-framework' ) );
 	}

--- a/inc/Provider.php
+++ b/inc/Provider.php
@@ -181,7 +181,7 @@ abstract class Provider {
 			throw new Exception(
 				sprintf(
 					/* translators: %s: Error message */
-					__( 'Error fetching media: %s', 'asset-manager-framework' ),
+					__( 'Media error: %s', 'asset-manager-framework' ),
 					$response->get_error_message()
 				)
 			);
@@ -201,7 +201,7 @@ abstract class Provider {
 			throw new Exception(
 				sprintf(
 					/* translators: %s: Error message */
-					__( 'Error fetching media: %s', 'asset-manager-framework' ),
+					__( 'Media error: %s', 'asset-manager-framework' ),
 					$message
 				)
 			);

--- a/inc/Provider.php
+++ b/inc/Provider.php
@@ -163,15 +163,14 @@ abstract class Provider {
 	}
 
 	/**
-	 * Performs an HTTP API request and returns the response. Abstracts away the HTTP error handling so
-	 * an implementation only needs to concern itself with the happy path.
+	 * Performs an HTTP API request and returns the WordPress HTTP API response.
 	 *
 	 * @param string $url The URL for the request.
 	 * @param array  $args The arguments to pass to `wp_remote_request()`.
-	 * @throws Exception Thrown if there is an error with the request or its response code is not 200.
-	 * @return string The response body.
+	 * @throws Exception Thrown if there is an error with the request.
+	 * @return array The WordPress HTTP API response.
 	 */
-	final public function remote_request( string $url, array $args ) : string {
+	final public function send_remote_request( string $url, array $args ) : array {
 		$response = wp_remote_request(
 			$url,
 			$args
@@ -186,6 +185,21 @@ abstract class Provider {
 				)
 			);
 		}
+
+		return $response;
+	}
+
+	/**
+	 * Performs an HTTP API request and returns the response. Abstracts away the HTTP error handling so
+	 * an implementation only needs to concern itself with the happy path.
+	 *
+	 * @param string $url The URL for the request.
+	 * @param array  $args The arguments to pass to `wp_remote_request()`.
+	 * @throws Exception Thrown if there is an error with the request or its response code is not 200.
+	 * @return string The response body.
+	 */
+	final public function remote_request( string $url, array $args ) : string {
+		$response = $this->send_remote_request( $url, $args );
 
 		$response_code = wp_remote_retrieve_response_code( $response );
 		$response_message = wp_remote_retrieve_response_message( $response );


### PR DESCRIPTION
See #25 

Work in progress

* [x] Support for uploads via `async-upload.php` when the action is `upload-attachment`
   - Used by the media manager
* [ ] Support for uploads via `async-upload.php` when the action is otherwise
   - Used when uploading from the Media admin screen
* [ ] Support for uploads via the REST API
   - Used when uploading directly into a media block in the block editor