### PR TITLE
Ensure sizes array element exists

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -375,6 +375,10 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 		return $metadata;
 	}
 
+	if ( ! isset( $metadata['sizes'] ) ) {
+		$metadata['sizes'] = [];
+	}
+
 	// Use the full size if available or create a fallback from the main file metadata.
 	$fallback_size = $metadata['sizes']['full'] ?? [
 		'file' => wp_unslash( get_post_meta( $attachment_id, '_amf_source_url', true ) ),


### PR DESCRIPTION
In situations where there are no sizes defined in the metadata, PHP throws a fatal error when trying to access them without checking first.

This PR ensures sizes exists and defaults to an empty array in case it doesn't.