### PR TITLE
prevent fatal error if sizes are missing from metadata

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -383,10 +383,10 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 		'mime-type' => $attachment->post_mime_type,
 	];
 
-	$missing_sizes = array_diff(
+	$missing_sizes = isset( $metadata['sizes'] ) ? array_diff(
 		get_intermediate_image_sizes(),
 		array_keys( $metadata['sizes'] )
-	);
+	) : get_intermediate_image_sizes();
 
 	// Populate missing image sizes from original.
 	foreach ( $missing_sizes as $size ) {


### PR DESCRIPTION
I was getting fatal errors in the Media Library after updating everything before recording my demo. The error was indicating that it was a result of a false value being passed into `array_keys`. This makes sure that `$metadata['sizes']` is set before passing it into the `array_keys` function.
