### PR TITLE
Fix fatal when media details is stdClass for non image assets

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -336,7 +336,7 @@ function fix_rest_attachment_urls( WP_REST_Response $response, WP_Post $attachme
 
 	$data = $response->get_data();
 
-	if ( ! empty( $data['media_details']['sizes'] ) && is_array( $data['media_details']['sizes'] ) ) {
+	if ( ! empty( $data['media_details'] ) && is_array( $data['media_details'] ) && ! empty( $data['media_details']['sizes'] ) && is_array( $data['media_details']['sizes'] ) ) {
 		foreach ( $data['media_details']['sizes'] as $name => $size ) {
 			$data['media_details']['sizes'][ $name ]['source_url'] = fix_media_url( $size['source_url'], $attachment );
 		}


### PR DESCRIPTION
See https://github.com/WordPress/wordpress-develop/blob/19751bd0d37000f910446d010d7ac9df6eb75d2d/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php#L758

Follow up to https://github.com/humanmade/asset-manager-framework/pull/43