### PR TITLE
Add filter for local provider name

### DIFF
--- a/inc/LocalProvider.php
+++ b/inc/LocalProvider.php
@@ -15,7 +15,7 @@ class LocalProvider extends Provider {
 	}
 
 	public function get_name() : string {
-		return __( 'Local Media', 'asset-manager-framework' );
+		return apply_filters( 'amf/local_provider/name', __( 'Local Media', 'asset-manager-framework' ) );
 	}
 
 	protected function request( array $args ) : MediaList {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-manager-framework",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "A framework for overriding the WordPress media library with an external asset provider.",
   "author": "Human Made",
   "license": "GPL-2.0-or-later",

--- a/plugin.php
+++ b/plugin.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name:  Asset Manager Framework
  * Description:  A framework for overriding the WordPress media library with an external asset provider.
- * Version:      0.10.2
+ * Version:      0.10.3
  * Plugin URI:   https://github.com/humanmade/asset-manager-framework
  * Author:       Human Made
  * Author URI:   https://humanmade.com/

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,7 @@ Local media is supported by default and can be used side by side with any additi
 
 1. Defining the `AMF_ALLOW_LOCAL_MEDIA` constant as a boolean
 2. Use the `amf/allow_local_media` filter to return a boolean
+3. Use the `amf/local_provider/name` filter to change the `Local Media` label.
 
 The filter will take precedence over the constant.
 


### PR DESCRIPTION
Add filter `amf/local_provider/name`, which allows you to change the local provider name.

fixes #47