### PR TITLE
Avoid PHP error if $attachment_id is null

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -438,7 +438,11 @@ function get_valid_dimensions( $size, int $max_width = 0, int $max_height = 0 ) 
 	return [ $width, $height, $crop ];
 }
 
-function dynamic_downsize( $downsize, int $attachment_id, $size ) {
+function dynamic_downsize( $downsize, $attachment_id, $size ) {
+	if ( ! $attachment_id ) {
+		return $downsize;
+	}
+	
 	$attachment = get_post( $attachment_id );
 
 	$provider = get_asset_provider( $attachment );


### PR DESCRIPTION
Faced some scenarios where $attachment_id is null and therefore `dynamic_downsize()` fails with an error. This avoids throwing error by bypassing the hook if there is no $attachment_id to work with.