### PR TITLE
Return an empty string when there is no file.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -211,7 +211,7 @@ function ajax_select() : void {
 	wp_send_json_success( $attachments );
 }
 
-function replace_attached_file( $file, int $attachment_id ) : string {
+function replace_attached_file( $file, int $attachment_id ) {
 	$attachment = get_post( $attachment_id );
 	if ( ! is_amf_asset( $attachment ) ) {
 		return $file;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -214,7 +214,7 @@ function ajax_select() : void {
 function replace_attached_file( $file, int $attachment_id ) : string {
 	$attachment = get_post( $attachment_id );
 	if ( ! is_amf_asset( $attachment ) ) {
-		return ( $file ? $file : '' );
+		return $file;
 	}
 
 	$metadata = wp_get_attachment_metadata( $attachment_id, true );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -214,7 +214,7 @@ function ajax_select() : void {
 function replace_attached_file( $file, int $attachment_id ) : string {
 	$attachment = get_post( $attachment_id );
 	if ( ! is_amf_asset( $attachment ) ) {
-		return $file;
+		return ( $file ? $file : '' );
 	}
 
 	$metadata = wp_get_attachment_metadata( $attachment_id, true );
@@ -442,7 +442,7 @@ function dynamic_downsize( $downsize, $attachment_id, $size ) {
 	if ( ! $attachment_id ) {
 		return $downsize;
 	}
-	
+
 	$attachment = get_post( $attachment_id );
 
 	$provider = get_asset_provider( $attachment );


### PR DESCRIPTION
### Issue
Related Issue : https://github.com/humanmade/asset-manager-framework/issues/54

> Fatal error: Uncaught Error: Return value of AssetManagerFramework\replace_attached_file() must be of the type string, bool returned
in /usr/src/app/vendor/humanmade/asset-manager-framework/inc/namespace.php on line 217

`replace_attached_file` when returning $file and $file is a boolean it throws the above error.

### Fix
When returning `$file` in the `replace_attached_file` function, rather than returning the boolean an empty string is returned.

### Steps to replicate

- On a multisite install with at least two sites
- Ensure WooCommerce is installed and network active
- Ensure MultilingualPress is installed and network active
- Ensure MultilingualPress has been configured to work with WooCommerce in the settings screen, and the Product post type is translatable
- Create a new Woo product, give it a test title and some content
- In the Product data meta box, set the project type to Variable product
- In the attributes tab Add an attribute, something like Attribute 1 with the values 1 | 2, be sure to save the attributes when you have finished
- In the Variations tab generate the variations from the attributes
- Publish the product
- Scroll down to the Translation for... that relates to the other site on your network
- Click the Create a new Product, and use it as translation in... radio button
- Click the post publish button to trigger the translation
- No error should be shown 🍾 
