### PR TITLE
Ensure an image with no size meta, has the appropriate size meta.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -397,9 +397,18 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 		array_keys( $metadata['sizes'] )
 	);
 
-	// Populate missing image sizes from original.
+	// List all currently registered image sub-sizes.
+	$registered_images = wp_get_registered_image_subsizes();
+
+	// Populate missing image sizes with the registered image size values.
 	foreach ( $missing_sizes as $size ) {
-		$metadata['sizes'][ $size ] = $fallback_size;
+		if ( isset( $registered_images[$size] ) ) {
+			$metadata['sizes'][ $size ] = $registered_images[$size];
+			$metadata['sizes'][ $size ]['file'] = wp_unslash( get_post_meta( $attachment_id, '_amf_source_url', true ) );
+			$metadata['sizes'][ $size ]['mime-type'] = $attachment->post_mime_type;
+		} else {
+			$metadata['sizes'][ $size ] = $fallback_size;
+		}
 	}
 
 	return $metadata;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -397,14 +397,15 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 		array_keys( $metadata['sizes'] )
 	);
 
-	// List all currently registered image sub-sizes.
-	$registered_images = wp_get_registered_image_subsizes();
-
 	// Populate missing image sizes with the registered image size values.
 	foreach ( $missing_sizes as $size ) {
-		if ( isset( $registered_images[$size] ) ) {
-			$metadata['sizes'][ $size ] = $registered_images[$size];
-			$metadata['sizes'][ $size ]['file'] = wp_unslash( get_post_meta( $attachment_id, '_amf_source_url', true ) );
+
+		$image = dynamic_downsize( false, $attachment_id, $size );
+
+		if ( $image ) {
+			$metadata['sizes'][ $size ]['file'] = wp_unslash( $image[0] );
+			$metadata['sizes'][ $size ]['width'] = $image[1];
+			$metadata['sizes'][ $size ]['height'] = $image[2];
 			$metadata['sizes'][ $size ]['mime-type'] = $attachment->post_mime_type;
 		} else {
 			$metadata['sizes'][ $size ] = $fallback_size;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -400,7 +400,7 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 	// Populate missing image sizes with the registered image size values.
 	foreach ( $missing_sizes as $size ) {
 
-		// Determine if the image supports resizing and retrieve the image's size and the correct url.
+		// Determine if the image supports resizing and retrieve the image's size and the resized url.
 		$image = dynamic_downsize( false, $attachment_id, $size );
 
 		// Check the image attributes are set first ( url, width & height ).

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -402,7 +402,7 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 
 		$image = dynamic_downsize( false, $attachment_id, $size );
 
-		if ( $image ) {
+		if ( $image && isset( $image[0] ) && isset( $image[1] ) && isset( $image[2] ) ) {
 			$metadata['sizes'][ $size ]['file'] = wp_unslash( $image[0] );
 			$metadata['sizes'][ $size ]['width'] = $image[1];
 			$metadata['sizes'][ $size ]['height'] = $image[2];

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -402,6 +402,7 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 
 		$image = dynamic_downsize( false, $attachment_id, $size );
 
+		// check the image attributes are set first ( url, width & height ).
 		if ( $image && isset( $image[0] ) && isset( $image[1] ) && isset( $image[2] ) ) {
 			$metadata['sizes'][ $size ]['file'] = wp_unslash( $image[0] );
 			$metadata['sizes'][ $size ]['width'] = $image[1];

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -400,10 +400,11 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 	// Populate missing image sizes with the registered image size values.
 	foreach ( $missing_sizes as $size ) {
 
+		// Determine if the image supports resizing and retrieve the image's size and the correct url.
 		$image = dynamic_downsize( false, $attachment_id, $size );
 
-		// check the image attributes are set first ( url, width & height ).
-		if ( $image && isset( $image[0] ) && isset( $image[1] ) && isset( $image[2] ) ) {
+		// Check the image attributes are set first ( url, width & height ).
+		if ( is_array( $image ) ) {
 			$metadata['sizes'][ $size ]['file'] = wp_unslash( $image[0] );
 			$metadata['sizes'][ $size ]['width'] = $image[1];
 			$metadata['sizes'][ $size ]['height'] = $image[2];

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -404,7 +404,7 @@ function add_fallback_sizes( array $metadata, int $attachment_id ) : array {
 		$image = dynamic_downsize( false, $attachment_id, $size );
 
 		// Check the image attributes are set first ( url, width & height ).
-		if ( is_array( $image ) ) {
+		if ( is_array( $image ) && isset( $image[0], $image[1], $image[2] ) ) {
 			$metadata['sizes'][ $size ]['file'] = wp_unslash( $image[0] );
 			$metadata['sizes'][ $size ]['width'] = $image[1];
 			$metadata['sizes'][ $size ]['height'] = $image[2];


### PR DESCRIPTION
##### Related Issue
https://github.com/humanmade/altis-cms/issues/626 An image renders an incorrect size to what was expected when viewing the editing a post. 

The image had no appropriate sizing for the different registered sizes. All registered image sizes were being given the full dimensions of the image but rendered at a different size.

##### Solution
Ensure that the registered image sizes are applied to the relevant sizes rather than applying the full image dimensions to each registered size. The full dimensions are used as a fallback.
