### PR TITLE
Allow nullable argument in fix_media_url

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -329,7 +329,7 @@ function get_asset_provider( ?WP_Post $attachment ) : ?Provider {
 	return $provider;
 }
 
-function fix_media_url( $url, WP_Post $attachment ) : string {
+function fix_media_url( $url, ?WP_Post $attachment ) : string {
 	if ( empty( $url ) || ! is_amf_asset( $attachment ) ) {
 		return $url ?: '';
 	}


### PR DESCRIPTION
This PR will fix fatal error thrown because the image attachment could return null in this line:
https://github.com/humanmade/asset-manager-framework/blob/1b02e24321c22a32cb45dbeffb5560626e5e09ee/inc/namespace.php#L353

In `fix_media_url` second argument the post argument should be able to accept null value. and it's already do the sanity check in this line: https://github.com/humanmade/asset-manager-framework/blob/1b02e24321c22a32cb45dbeffb5560626e5e09ee/inc/namespace.php#L333 